### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/delano/zed-mcp-server-serena/security/code-scanning/2](https://github.com/delano/zed-mcp-server-serena/security/code-scanning/2)

To fix the problem, add a `permissions` block at the workflow root level in `.github/workflows/ci.yml`. This block should set `contents: read` so that the GITHUB_TOKEN provided to all jobs in the workflow only has read access to repository contents—which is more secure and meets the principle of least privilege. Place the permissions block immediately after the `name:` line and before the `on:` block, as per GitHub Actions best practices.

No changes are needed to any other part of the file, since no steps write to issues, pull requests, or repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
